### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,6 +2,9 @@ name: Build and test Jekyll USWDS
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Install, build and test site with pa11y-ci and htmlproofer.


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/assets.FCSM/security/code-scanning/1](https://github.com/GSA/assets.FCSM/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the steps in the workflow, it appears that the workflow only needs to read the repository contents (e.g., to check out the source code). Therefore, we will set `contents: read` as the permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
